### PR TITLE
Change python `True` to ruby `true`

### DIFF
--- a/library/my_ruby_calculator
+++ b/library/my_ruby_calculator
@@ -18,7 +18,7 @@ File.open(ARGV[0]) do |fh|
       # to raise an error, return failed=True and a msg string.
 
       print JSON.dump({
-          'failed' => True,
+          'failed' => true,
           'msg'    => 'failed to parse inputs x or y'
       })
 


### PR DESCRIPTION
This example fails in the error condition because ruby's boolean operator is `true` not `True`.  Just a quick fix.  Thanks for the examples.
