### PR TITLE
Update documentation and calculator syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ module can return facts.
 The example Ruby utility module, like the fact module, simply reads an input file specified as the first argument to
 the program as JSON, and outputs JSON.
 
+Reading Input
+=============
+
+Ansible internally saves arguments to an arguments file. So we must read the file and parse it. The arguments file is just a string, so any form of arguments are legal.
+
+The line `# WANT_JSON` at the top of `my_ruby_calculator` is magic, and tells Ansible to pass JSON to your module. Without this, you'll receive the arguments as the raw text provided.
+
 Conventions of JSON output
 ==========================
 

--- a/library/my_ruby_calculator
+++ b/library/my_ruby_calculator
@@ -1,42 +1,36 @@
 #!/usr/bin/ruby
 # WANT_JSON
 
-require 'rubygems'
 require 'json'
 
 # this is a bare minimum example of a 'facts' module that returns some variables into the ansible
-# namespace.  It may not be sufficiently idiomatic and doesn't do a lot of error checking. 
+# namespace. it is written to run in ruby 1.9 or greater.
 
-File.open(ARGV[0]) do |fh|
+args = JSON.parse(File.read ARGV[0])
 
-   data = JSON.parse(fh.read())
+begin
+  a = args['a'].to_i
+  b = args['b'].to_i
+rescue
+  # to raise an error, return failed=True and a msg string.
 
-   begin
-      a = data['a'].to_i() 
-      b = data['b'].to_i()
-   rescue
-      # to raise an error, return failed=True and a msg string.
+  print JSON.dump({
+    failed: true,
+    msg: 'failed to parse inputs x or y'
+  })
 
-      print JSON.dump({
-          'failed' => true,
-          'msg'    => 'failed to parse inputs x or y'
-      })
-
-      # the error code here is not so important, the JSON is!
-
-      exit(1)
-   end
-
-   # we may also wish to return changed=True or changed=False
-   # if we were modifying system resources to support handlers and change tracking
-   # if the module decides to not run, it can also return skipped=True
-
-   result = {
-      'a'   => a,
-      'b'   => b,
-      'sum' => a + b,
-   }
-
-   print JSON.dump(result)
-
+  # the error code here is not so important, the JSON is!
+  exit(1)
 end
+
+# we may also wish to return changed=True or changed=False
+# if we were modifying system resources to support handlers and change tracking
+# if the module decides to not run, it can also return skipped=True
+
+result = {
+  a: a,
+  b: b,
+  sum: a + b,
+}
+
+print JSON.dump(result)


### PR DESCRIPTION
- I added a note about #WANT_JSON in the Readme, this is a pretty important line to omit any mention of.
- I updated the calculator to have more modern syntax, this breaks support for Ruby 1.8, but this is disclosed and anyone writing a Ruby module today is probably aware of the differences.
